### PR TITLE
Fix .eqv char literal bad substitution

### DIFF
--- a/src/rars/assembler/OperandFormat.java
+++ b/src/rars/assembler/OperandFormat.java
@@ -113,7 +113,7 @@ public class OperandFormat {
             // Not an error if spec calls for identifier and candidate is operator, since operator names can be used as labels.
             // TODO: maybe add more cases in here
             if (specType == TokenTypes.IDENTIFIER && candType == TokenTypes.OPERATOR) {
-                Token replacement = new Token(TokenTypes.IDENTIFIER, candToken.getValue(), candToken.getSourceProgram(), candToken.getSourceLine(), candToken.getStartPos());
+                Token replacement = new Token(TokenTypes.IDENTIFIER, candToken.getValue(), candToken.getSourceProgram(), candToken.getSourceLine(), candToken.getStartPos(), candToken.getOriginalText());
                 cand.set(i, replacement);
                 continue;
             }

--- a/src/rars/assembler/Token.java
+++ b/src/rars/assembler/Token.java
@@ -47,6 +47,7 @@ public class Token {
     // original program and line will differ from the above if token was defined in an included file
     private RISCVprogram originalProgram;
     private int originalSourceLine;
+    private String originalText;
 
     /**
      * Constructor for Token class.
@@ -59,7 +60,7 @@ public class Token {
      * @see TokenTypes
      **/
 
-    public Token(TokenTypes type, String value, RISCVprogram sourceProgram, int line, int start) {
+    public Token(TokenTypes type, String value, RISCVprogram sourceProgram, int line, int start, String originalText) {
         this.type = type;
         this.value = value;
         this.sourceProgram = sourceProgram;
@@ -67,6 +68,7 @@ public class Token {
         this.sourcePos = start;
         this.originalProgram = sourceProgram;
         this.originalSourceLine = line;
+        this.originalText = originalText;
     }
 
 
@@ -101,6 +103,10 @@ public class Token {
      **/
     public int getOriginalSourceLine() {
         return this.originalSourceLine;
+    }
+
+    public String getOriginalText() {
+        return this.originalText;
     }
 
     /**

--- a/src/rars/assembler/Token.java
+++ b/src/rars/assembler/Token.java
@@ -105,6 +105,13 @@ public class Token {
         return this.originalSourceLine;
     }
 
+    /**
+     * Produces the token's original text. In most cases, this is equivalent to
+     * {@code Token.getValue()} but when the token is a character literal this
+     * will return {@code "'a'"} rather then {@code getValue}'s {@code "97"}.
+     *
+     * @return original text representing this token
+     **/
     public String getOriginalText() {
         return this.originalText;
     }

--- a/src/rars/assembler/Tokenizer.java
+++ b/src/rars/assembler/Tokenizer.java
@@ -339,7 +339,7 @@ public class Tokenizer {
                         tokenStartPos = linePos + 1;
                         token[tokenPos++] = c;
                         if (line.length > linePos + 3 && line[linePos + 1] == 'I' && line[linePos + 2] == 'n' && line[linePos + 3] == 'f') {
-                            result.add(new Token(TokenTypes.REAL_NUMBER, "-Inf", program, lineNum, tokenStartPos));
+                            result.add(new Token(TokenTypes.REAL_NUMBER, "-Inf", program, lineNum, tokenStartPos, "-Inf"));
                             linePos += 3;
                             tokenPos = 0;
                             break;
@@ -491,7 +491,7 @@ public class Tokenizer {
                 // multiple tokens, so I want to get everything from the IDENTIFIER to either the
                 // COMMENT or to the end.
                 int startExpression = tokens.get(dirPos + 2).getStartPos();
-                int endExpression = tokens.get(tokenPosLastOperand).getStartPos() + tokens.get(tokenPosLastOperand).getValue().length();
+                int endExpression = tokens.get(tokenPosLastOperand).getStartPos() + tokens.get(tokenPosLastOperand).getOriginalText().length();
                 String expression = theLine.substring(startExpression - 1, endExpression - 1);
                 // Symbol cannot be redefined - the only reason for this is to act like the Gnu .eqv
                 if (equivalents.containsKey(symbol) && !equivalents.get(symbol).equals(expression)) {
@@ -536,13 +536,14 @@ public class Tokenizer {
     private void processCandidateToken(char[] token, RISCVprogram program, int line, String theLine,
                                        int tokenPos, int tokenStartPos, TokenList tokenList) {
         String value = new String(token, 0, tokenPos);
+        String original = value;
         if (value.length() > 0 && value.charAt(0) == '\'') value = preprocessCharacterLiteral(value);
         TokenTypes type = TokenTypes.matchTokenType(value);
         if (type == TokenTypes.ERROR) {
             errors.add(new ErrorMessage(program, line, tokenStartPos,
                     theLine + "\nInvalid language element: " + value));
         }
-        Token toke = new Token(type, value, program, line, tokenStartPos);
+        Token toke = new Token(type, value, program, line, tokenStartPos, original);
         tokenList.add(toke);
     }
 

--- a/test/eqv_char.s
+++ b/test/eqv_char.s
@@ -1,0 +1,8 @@
+.eqv SUBSTITUTE 'a'     # a is 97
+
+.text
+        li s0, SUBSTITUTE       # this must build
+
+        li a0, 42
+        li a7, 93
+        ecall


### PR DESCRIPTION
I found a bug where `.eqv` would fail to be substituted if the expression was a character-literal and if that character's ASCII value was less than 100.

In pseudocode, the bug went like this:
```asm
.eqv SUB 'a'
```
`.eqv`'s expression would be tokenised as `"'a'"` which is correct
when converting this text token into a `Token` `"'a'"` would be converted to `"97"`

later, the `.eqv` code would attempt to get the original expression by doing something like
```c
lines_of_code[token.originalLine()].substr(token.start(), token.star() + token.value().lenght())
```
In the case of `'a'` the value's length would be 2, but the original token's would be 3.
This would result in `SUB` being replaced by `'a` in the source code.

Other letters, such as `g`(103), do not have the same problem because their value's length equals their original token's text.

This PR fixes this problem by adding the original token's text to each token and using that text to compute the expression's substring.