### PR TITLE
add back Interactive Mode

### DIFF
--- a/src/rars/Settings.java
+++ b/src/rars/Settings.java
@@ -138,6 +138,10 @@ public class Settings extends Observable {
          */
         POPUP_SYSCALL_INPUT("PopupSyscallInput", false),
         /**
+         * Flag to controg whether or not the run I/O mode is batch (true) or interactive (false).
+         */
+        BATCH_IOMODE("BatchIOMode", false),
+        /**
          * Flag to control whether or not to use generic text editor instead of language-aware styled editor
          */
         GENERIC_TEXT_EDITOR("GenericTextEditor", false),

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -295,7 +295,7 @@ public class SystemIO {
         /// Read from STDIN file descriptor while using IDE - get input from Messages pane.
         if (fd == STDIN && Globals.getGui() != null) {
             //asks user for input in run pane
-            if (Globals.getGui().getMessagesPane().getInputField().isEmpty()) {
+            if (Globals.getGui().getMessagesPane().isInteractiveMode()) {
                 String input = Globals.getGui().getMessagesPane().getInputString(lengthRequested);
                 return readInBuffer(input, myBuffer);
             //takes input from input pane

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -301,10 +301,10 @@ public class SystemIO {
             //takes input from input pane
             } else {
                 try {
-                    String input = "";
-                    for (int i = 0; i < myBuffer.length; i++) {
-                        input = input + (char) getInputReaderFromGui().read();
-                    }
+                    char[] chars = new char[lengthRequested];
+                    int len = getInputReaderFromGui().read(chars);
+                    if (len <= 0) return len;
+                    String input = new String(chars);
                     return readInBuffer(input, myBuffer);
                 } catch (IOException e) {
                     fileErrorString = "IO Exception on read from the input window of GUI";

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -102,7 +102,7 @@ public class SystemIO {
         } else {
             if (Globals.getSettings().getBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT)) {
                 input = Globals.getGui().getMessagesPane().getInputString(prompt);
-            } else if (!Globals.getGui().getMessagesPane().getInputField().isEmpty()) {
+            } else if (!Globals.getGui().getMessagesPane().isInteractiveMode()) {
                 try {
                     input = getInputReaderFromGui().readLine();
                     if (input == null)

--- a/src/rars/venus/MessagesPane.java
+++ b/src/rars/venus/MessagesPane.java
@@ -54,8 +54,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 public class MessagesPane extends JPanel {
     private JTabbedPane leftPane;
-    private JTabbedPane rightPane;
-    private JSplitPane splitter;
+    private JSplitPane batchTab;
     JTextArea assemble, run, input, output;
     private JPanel assembleTab, runTab, inputTab, outputTab;
     // These constants are designed to keep scrolled contents of the
@@ -75,7 +74,6 @@ public class MessagesPane extends JPanel {
         super();
         this.setMinimumSize(new Dimension(0, 0));
         leftPane = new JTabbedPane();
-        rightPane = new JTabbedPane();
         assemble = new JTextArea();
         run = new JTextArea();
         input = new JTextArea();
@@ -183,7 +181,7 @@ public class MessagesPane extends JPanel {
         runTab.add(new JScrollPane(run, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED), BorderLayout.CENTER);
 
-        JButton inputTabClearButton = new JButton("Clear");
+        JButton inputTabClearButton = new JButton("Clear input");
         inputTabClearButton.setToolTipText("Clear the input area");
         inputTabClearButton.addActionListener(
                 new ActionListener() {
@@ -196,7 +194,7 @@ public class MessagesPane extends JPanel {
         inputTab.add(new JScrollPane(input, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED), BorderLayout.CENTER);
 
-        JButton outputTabClearButton = new JButton("Clear");
+        JButton outputTabClearButton = new JButton("Clear output");
         outputTabClearButton.setToolTipText("Clear the Output area");
         outputTabClearButton.addActionListener(
                 new ActionListener() {
@@ -209,24 +207,22 @@ public class MessagesPane extends JPanel {
         outputTab.add(new JScrollPane(output, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED), BorderLayout.CENTER);
 
+        batchTab = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, inputTab, outputTab);
+        batchTab.setOneTouchExpandable(true);
+        batchTab.resetToPreferredSizes();
+        batchTab.setResizeWeight(0.5);
+
         leftPane.addTab("Messages", assembleTab);
-        leftPane.addTab("Run", runTab);
-        leftPane.addTab("Input", inputTab);
+        leftPane.addTab("Interactive", runTab);
+        leftPane.addTab("Batch", batchTab);
         leftPane.setForeground(Color.BLACK);
-        rightPane.addTab("Output", outputTab);
-        rightPane.setForeground(Color.BLACK);
 
         leftPane.setToolTipTextAt(0, "Messages produced by Run menu. Click on assemble error message to select erroneous line");
         leftPane.setToolTipTextAt(1, "Simulated console input (used while running) and other run messages");
         leftPane.setToolTipTextAt(2, "Simulated console input (to use before running)");
-        rightPane.setToolTipTextAt(0, "Simulated console output");
 
-        splitter = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPane, rightPane);
-        splitter.setOneTouchExpandable(true);
-        splitter.resetToPreferredSizes();
-        splitter.setResizeWeight(0.5);
         this.setLayout(new BorderLayout());
-        this.add(splitter);
+        this.add(leftPane);
     }
 
     // Center given button in a box, centered vertically and 6 pixels on left and right
@@ -384,8 +380,13 @@ public class MessagesPane extends JPanel {
         SwingUtilities.invokeLater(
                 new Runnable() {
                     public void run() {
-                        leftPane.setSelectedComponent(runTab);
+                        if (isInteractiveMode()) {
+                            leftPane.setSelectedComponent(runTab);
+                        } else {
+                            leftPane.setSelectedComponent(batchTab);
+                        }
                         append(run, mess);
+                        append(output, mess);
                     }
                 });
     }
@@ -400,6 +401,7 @@ public class MessagesPane extends JPanel {
         SwingUtilities.invokeLater(
                 new Runnable() {
                     public void run() {
+                        append(run, mess);
                         append(output, mess);
                     }
                 });

--- a/src/rars/venus/MessagesPane.java
+++ b/src/rars/venus/MessagesPane.java
@@ -380,11 +380,7 @@ public class MessagesPane extends JPanel {
         SwingUtilities.invokeLater(
                 new Runnable() {
                     public void run() {
-                        if (isInteractiveMode()) {
-                            leftPane.setSelectedComponent(runTab);
-                        } else {
-                            leftPane.setSelectedComponent(batchTab);
-                        }
+                        selectRunMessageTab();
                         append(run, mess);
                         append(output, mess);
                     }
@@ -418,7 +414,11 @@ public class MessagesPane extends JPanel {
      * Make the runtime message tab current (up front)
      */
     public void selectRunMessageTab() {
-        leftPane.setSelectedComponent(runTab);
+        if (isInteractiveMode()) {
+            leftPane.setSelectedComponent(runTab);
+        } else {
+            leftPane.setSelectedComponent(batchTab);
+        }
     }
 
     /**

--- a/src/rars/venus/MessagesPane.java
+++ b/src/rars/venus/MessagesPane.java
@@ -59,6 +59,7 @@ public class MessagesPane extends JPanel {
     private final JRadioButton buttonInteractive;
     private final JRadioButton buttonBatch;
     private final JButton inputTabClearButton;
+    private final Box runioContent;
     private JTabbedPane leftPane;
     private JSplitPane batchTab;
     JTextArea assemble, run, input, output;
@@ -242,7 +243,10 @@ public class MessagesPane extends JPanel {
         batchTab.setResizeWeight(0.5);
 
         /* The runio, the content is dynamic */
+        runioContent = Box.createHorizontalBox();
         runioTab = new JPanel(new BorderLayout());
+        runioTab.add(createBoxForButton(runButtonBox), BorderLayout.WEST);
+        runioTab.add(runioContent);
         updateIOTab();
 
         leftPane.addTab("Messages", assembleTab);
@@ -258,16 +262,15 @@ public class MessagesPane extends JPanel {
 
     /** Update the content of the runio tab according to the selected radio buttons. */
     private void updateIOTab() {
-        runioTab.removeAll();
-        runioTab.add(createBoxForButton(runButtonBox), BorderLayout.WEST);
+        runioContent.removeAll();
         if (buttonBatch.isSelected() ) {
             Globals.getSettings().setBooleanSetting(Settings.Bool.BATCH_IOMODE, true);
             Globals.getSettings().setBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT, false);
-            runioTab.add(batchTab);
+            runioContent.add(batchTab);
             inputTabClearButton.setEnabled(true);
         } else {
             Globals.getSettings().setBooleanSetting(Settings.Bool.BATCH_IOMODE, false);
-            runioTab.add(runTab);
+            runioContent.add(runTab);
             Globals.getSettings().setBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT, buttonPopup.isSelected());
             inputTabClearButton.setEnabled(false);
         }

--- a/src/rars/venus/MessagesPane.java
+++ b/src/rars/venus/MessagesPane.java
@@ -342,24 +342,29 @@ public class MessagesPane extends JPanel {
         return input.getText();
     }
 
+    /** Append a message to a textarea and garbage collect very old text if needed. */
+    private void append(JTextArea area, String string) {
+        area.append(string);
+        // can do some crude cutting here.  If the document gets "very large",
+        // let's cut off the oldest text. This will limit scrolling but the limit
+        // can be set reasonably high.
+        if (area.getDocument().getLength() > MAXIMUM_SCROLLED_CHARACTERS) {
+            try {
+                area.getDocument().remove(0, NUMBER_OF_CHARACTERS_TO_CUT);
+            } catch (BadLocationException ble) {
+                // only if NUMBER_OF_CHARACTERS_TO_CUT > MAXIMUM_SCROLLED_CHARACTERS
+            }
+        }
+        area.setCaretPosition(area.getDocument().getLength());
+    }
+
     /**
      * Post a message to the assembler display
      *
      * @param message String to append to assembler display text
      */
     public void postMessage(String message) {
-        assemble.append(message);
-        // can do some crude cutting here.  If the document gets "very large",
-        // let's cut off the oldest text. This will limit scrolling but the limit
-        // can be set reasonably high.
-        if (assemble.getDocument().getLength() > MAXIMUM_SCROLLED_CHARACTERS) {
-            try {
-                assemble.getDocument().remove(0, NUMBER_OF_CHARACTERS_TO_CUT);
-            } catch (BadLocationException ble) {
-                // only if NUMBER_OF_CHARACTERS_TO_CUT > MAXIMUM_SCROLLED_CHARACTERS
-            }
-        }
-        assemble.setCaretPosition(assemble.getDocument().getLength());
+        append(assemble, message);
         leftPane.setSelectedComponent(assembleTab);
     }
 
@@ -380,17 +385,7 @@ public class MessagesPane extends JPanel {
                 new Runnable() {
                     public void run() {
                         leftPane.setSelectedComponent(runTab);
-                        run.append(mess);
-                        // can do some crude cutting here.  If the document gets "very large",
-                        // let's cut off the oldest text. This will limit scrolling but the limit
-                        // can be set reasonably high.
-                        if (run.getDocument().getLength() > MAXIMUM_SCROLLED_CHARACTERS) {
-                            try {
-                                run.getDocument().remove(0, NUMBER_OF_CHARACTERS_TO_CUT);
-                            } catch (BadLocationException ble) {
-                                // only if NUMBER_OF_CHARACTERS_TO_CUT > MAXIMUM_SCROLLED_CHARACTERS
-                            }
-                        }
+                        append(run, mess);
                     }
                 });
     }
@@ -405,14 +400,7 @@ public class MessagesPane extends JPanel {
         SwingUtilities.invokeLater(
                 new Runnable() {
                     public void run() {
-                        output.append(mess);
-                        // as in method above: if document gets "very large", cuts off the oldest text.
-                        if (output.getDocument().getLength() > MAXIMUM_SCROLLED_CHARACTERS) {
-                            try {
-                                output.getDocument().remove(0, NUMBER_OF_CHARACTERS_TO_CUT);
-                            } catch (BadLocationException ble) {    // as above
-                            }
-                        }
+                        append(output, mess);
                     }
                 });
     }

--- a/src/rars/venus/MessagesPane.java
+++ b/src/rars/venus/MessagesPane.java
@@ -326,6 +326,14 @@ public class MessagesPane extends JPanel {
     }
 
     /**
+     * Return true if the execution is (or will be) in interactive mode and false for batch mode.
+     * Currently, batch mode means that the input field is not empty.
+     */
+    public Boolean isInteractiveMode() {
+        return input.getText().isEmpty();
+    }
+
+    /**
      * Returns the text written in the input field
      *
      * @return input text field content

--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -83,7 +83,7 @@ public class VenusUI extends JFrame {
     private JMenuItem fileNew, fileOpen, fileClose, fileCloseAll, fileSave, fileSaveAs, fileSaveAll, fileDumpMemory, fileExit;
     private JMenuItem editUndo, editRedo, editCut, editCopy, editPaste, editFindReplace, editSelectAll;
     private JMenuItem runGo, runStep, runBackstep, runReset, runAssemble, runStop, runPause, runClearBreakpoints, runToggleBreakpoints;
-    private JCheckBoxMenuItem settingsLabel, settingsPopupInput, settingsValueDisplayBase, settingsAddressDisplayBase,
+    private JCheckBoxMenuItem settingsLabel, settingsValueDisplayBase, settingsAddressDisplayBase,
             settingsExtended, settingsAssembleOnOpen, settingsAssembleAll, settingsAssembleOpen, settingsWarningsAreErrors,
             settingsStartAtMain, settingsProgramArguments, settingsSelfModifyingCode, settingsRV64, settingsDeriveCurrentWorkingDirectory;
     private JMenuItem settingsExceptionHandler, settingsEditor, settingsHighlighting, settingsMemoryConfiguration;
@@ -106,7 +106,7 @@ public class VenusUI extends JFrame {
     private Action editCutAction, editCopyAction, editPasteAction, editFindReplaceAction, editSelectAllAction;
     private Action runAssembleAction, runGoAction, runStepAction, runBackstepAction, runResetAction,
             runStopAction, runPauseAction, runClearBreakpointsAction, runToggleBreakpointsAction;
-    private Action settingsLabelAction, settingsPopupInputAction, settingsValueDisplayBaseAction, settingsAddressDisplayBaseAction,
+    private Action settingsLabelAction, settingsValueDisplayBaseAction, settingsAddressDisplayBaseAction,
             settingsExtendedAction, settingsAssembleOnOpenAction, settingsAssembleOpenAction, settingsAssembleAllAction,
             settingsWarningsAreErrorsAction, settingsStartAtMainAction, settingsProgramArgumentsAction,
             settingsExceptionHandlerAction, settingsEditorAction, settingsHighlightingAction, settingsMemoryConfigurationAction,
@@ -411,9 +411,6 @@ public class VenusUI extends JFrame {
                     System.out.println("ExecutePane reference 2");
                 }
             };
-            settingsPopupInputAction = new SettingsAction("Popup dialog for input syscalls (5,6,7,8,12)",
-                    "If set, use popup dialog for input syscalls (5,6,7,8,12) instead of cursor in Run I/O window",
-                    Settings.Bool.POPUP_SYSCALL_INPUT);
 
             settingsValueDisplayBaseAction = new SettingsAction("Values displayed in hexadecimal",
                     "Toggle between hexadecimal and decimal display of memory/register values",
@@ -613,8 +610,6 @@ public class VenusUI extends JFrame {
 
         settingsLabel = new JCheckBoxMenuItem(settingsLabelAction);
         settingsLabel.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.LABEL_WINDOW_VISIBILITY));
-        settingsPopupInput = new JCheckBoxMenuItem(settingsPopupInputAction);
-        settingsPopupInput.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT));
         settingsValueDisplayBase = new JCheckBoxMenuItem(settingsValueDisplayBaseAction);
         settingsValueDisplayBase.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.DISPLAY_VALUES_IN_HEX));//mainPane.getExecutePane().getValueDisplayBaseChooser().isSelected());
         // Tell the corresponding JCheckBox in the Execute Pane about me -- it has already been created.
@@ -650,7 +645,6 @@ public class VenusUI extends JFrame {
 
         settings.add(settingsLabel);
         settings.add(settingsProgramArguments);
-        settings.add(settingsPopupInput);
         settings.add(settingsAddressDisplayBase);
         settings.add(settingsValueDisplayBase);
         settings.addSeparator();

--- a/src/rars/venus/run/RunAssembleAction.java
+++ b/src/rars/venus/run/RunAssembleAction.java
@@ -138,6 +138,7 @@ public class RunAssembleAction extends GuiAction {
                 mainUI.setReset(true);
                 mainUI.setStarted(false);
                 mainUI.getMainPane().setSelectedComponent(executePane);
+                mainUI.getMessagesPane().selectRunMessageTab();
 
                 // Aug. 24, 2005 Ken Vollmar
                 SystemIO.resetFiles();  // Ensure that I/O "file descriptors" are initialized for a new program run


### PR DESCRIPTION
#3 proposed an output pane to separate the output from the rest of the messages and always have it visible.
By doing so, the default interactive mode where the user interact on a terminal-ish window was removed.

This PR adds it back : the "interactive" tab (was simply called "run" before) has a single text area.
The new "batch" tab has an input pane (write only) and an output pane (read only).

![Capture d’écran du 2024-06-27 18-13-45](https://github.com/privat/rars/assets/135828/6969c4ec-e0a5-4bd3-b80c-ed62197c8895)

![Capture d’écran du 2024-06-27 18-14-15](https://github.com/privat/rars/assets/135828/97ac69c8-1b38-4d77-a0aa-9dec8d553d8e)
