### PR TITLE
 readChar reject non ASCII and printChar is UTF-8 aware

### DIFF
--- a/src/rars/riscv/syscalls/SyscallPrintChar.java
+++ b/src/rars/riscv/syscalls/SyscallPrintChar.java
@@ -5,6 +5,8 @@ import rars.riscv.AbstractSyscall;
 import rars.riscv.hardware.RegisterFile;
 import rars.util.SystemIO;
 
+import java.nio.charset.StandardCharsets;
+
 /*
 Copyright (c) 2003-2006,  Pete Sanderson and Kenneth Vollmar
 
@@ -40,8 +42,9 @@ public class SyscallPrintChar extends AbstractSyscall {
     }
 
     public void simulate(ProgramStatement statement) {
-        char t = (char) (RegisterFile.getValue("a0") & 0x000000ff);
-        SystemIO.printString(Character.toString(t));
+        byte[] t = new byte[1];
+        t[0] = (byte) RegisterFile.getValue("a0");
+        SystemIO.printString(new String(t, StandardCharsets.UTF_8));
     }
 
 }

--- a/src/rars/riscv/syscalls/SyscallReadChar.java
+++ b/src/rars/riscv/syscalls/SyscallReadChar.java
@@ -41,9 +41,9 @@ public class SyscallReadChar extends AbstractSyscall {
 
     public void simulate(ProgramStatement statement) throws ExitingException {
         int character = SystemIO.readChar(this.getNumber());
-        if (character == -2) {
+        if (character == SystemIO.NOTASCII) {
             throw new ExitingException(statement,
-                    "invalid char input (syscall " + this.getNumber() + ")");
+                    "invalid or non printable ASCII input (syscall " + this.getNumber() + ")");
         }
         RegisterFile.updateRegister("a0", character);
     }

--- a/src/rars/riscv/syscalls/SyscallReadChar.java
+++ b/src/rars/riscv/syscalls/SyscallReadChar.java
@@ -40,13 +40,12 @@ public class SyscallReadChar extends AbstractSyscall {
     }
 
     public void simulate(ProgramStatement statement) throws ExitingException {
-        try {
-            RegisterFile.updateRegister("a0", SystemIO.readChar(this.getNumber()));
-        } catch (IndexOutOfBoundsException e) // means null input
-        {
+        int character = SystemIO.readChar(this.getNumber());
+        if (character == -2) {
             throw new ExitingException(statement,
                     "invalid char input (syscall " + this.getNumber() + ")");
         }
+        RegisterFile.updateRegister("a0", character);
     }
 
 }

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -76,6 +76,12 @@ public class SystemIO {
     private static final int STDOUT = 1;
     private static final int STDERR = 2;
 
+    // special result of readChar
+    /** End of stream reached */
+    public static final int EOF = -1;
+    /** the character is not a printable ASCII  */
+    public static final int NOTASCII = -2;
+
     /**
      * Implements syscall to read an integer value.
      * Client is responsible for catching NumberFormatException.
@@ -185,7 +191,7 @@ public class SystemIO {
      * Only printable characters are accepted (9, 10, and 32 to 126).
      *
      * @param serviceNumber the number assigned to Read Char syscall (default 12)
-     * @return int value with lowest byte corresponding to user input, -1 on EOF, or -2 on invalid ASCII character.
+     * @return int value with lowest byte corresponding to user input, EOF on end of data, or NOTASCII on invalid ASCII character.
      */
     public static int readChar(int serviceNumber) {
         int returnValue;
@@ -196,7 +202,7 @@ public class SystemIO {
             if (input.length()>0)
                 returnValue = input.getBytes(StandardCharsets.UTF_8) [0] & 0xFF; // truncate
             else
-                returnValue = -1; // assume EOF on empty string
+                returnValue = EOF; // assume EOF on empty string
         } else {
             // Otherwise delegate to the Read syscall
             byte[] input = new byte[1];
@@ -204,11 +210,11 @@ public class SystemIO {
             if (len>0)
                 returnValue = input[0] & 0xFF;
             else
-                returnValue = -1;
+                returnValue = EOF;
         }
 
         if ((returnValue < 32 || returnValue >= 127) && returnValue != -1 && returnValue != '\n' && returnValue != '\t') {
-            return -2;
+            return NOTASCII;
         }
 
         return returnValue;

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -182,9 +182,10 @@ public class SystemIO {
 
     /**
      * Implements syscall having 12 in $v0, to read a char value.
+     * Only printable characters are accepted (9, 10, and 32 to 126).
      *
      * @param serviceNumber the number assigned to Read Char syscall (default 12)
-     * @return int value with lowest byte corresponding to user input or -1 on EOF
+     * @return int value with lowest byte corresponding to user input, -1 on EOF, or -2 on invalid ASCII character.
      */
     public static int readChar(int serviceNumber) {
         int returnValue;
@@ -204,6 +205,10 @@ public class SystemIO {
                 returnValue = input[0] & 0xFF;
             else
                 returnValue = -1;
+        }
+
+        if ((returnValue < 32 || returnValue >= 127) && returnValue != -1 && returnValue != '\n' && returnValue != '\t') {
+            return -2;
         }
 
         return returnValue;

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -193,7 +193,7 @@ public class SystemIO {
         if (Globals.getGui() != null && Globals.getSettings().getBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT)) {
             String input = readStringInternal("0", "Enter a character value (syscall " + serviceNumber + ")", 1);
             if (input.length()>0)
-                returnValue = input.charAt(0); // truncate
+                returnValue = input.getBytes(StandardCharsets.UTF_8) [0] & 0xFF; // truncate
             else
                 returnValue = -1; // assume EOF on empty string
         } else {
@@ -201,7 +201,7 @@ public class SystemIO {
             byte[] input = new byte[1];
             int len = readFromFile(0, input, 1);
             if (len>0)
-                returnValue = input[0];
+                returnValue = input[0] & 0xFF;
             else
                 returnValue = -1;
         }

--- a/test/readchar.s
+++ b/test/readchar.s
@@ -1,5 +1,5 @@
 #stdin:a b\n\n!
-#stdout:97a32 98b10\n10\n33!-1ÿ-1ÿ
+#stdout:97a32 98b10\n10\n33!-1�-1�
 
 .eqv PrintInt, 1
 .eqv ReadChar, 12


### PR DESCRIPTION
Currently, input and output dealing with Unicode is inconsistent.

Some operation assumes UTF-8 where chars are just bytes and `'é'` is `c3 a9, some assume internal UTF-16, some other assumptions are platform dependent (because it is the *bad* default of many Java methods).

Previously:

* printChar prints the lowest bytes as a character, so if a0 is `a9c3` then `c3` is understood as a code-point, so `Ã` is printed.
* readChar depends on the mode, in terminal and GUI mode, it seems that utf-8 is used: bytes are read as is.  In popup mode, the code-point of the first character read is used, that might even set `a0` to a value larger than `0xff` or even negative

This PR makes both operations more consistent with a common UFT-8 encoding

* readChar read bytes, so if the input is `c3 a9`, readchar consume and return `c3` in all mode and systems
* printChar print the lowest byte as is, since `c3` alone is not a valid UTF-8 unicode character, a replacement character is displayed by the GUI.

Benefits:

* Behavior more consistent
* in case of bugs, replacement character likely used instead of some random character, making the behavior more explainable.

Problem that remain:

printChar print each character independent, so even is we printChar `c3` then `a3`, 2 replacement character will be issued instead of a single `é`.