### PR TITLE
improve command line interface: exit codes, stderr and version

### DIFF
--- a/src/help/Command.html
+++ b/src/help/Command.html
@@ -41,13 +41,12 @@ Option has 1 argument, e.g. <tt>mc &lt;config&gt;</tt>.  Argument <tt>&lt;config
 possible values are <tt>Default</tt> for the default 32-bit address space, <tt>CompactDataAtZero</tt> for
 a 32KB address space with data segment at address 0, or <tt>CompactTextAtZero</tt>
 for a 32KB address space with text segment at address 0.</td><td>3.7</td></tr>
-<tr><td width=40 align="right"><tt>me</tt></td><td>display RARS messages to standard err instead of standard out.  Allows you to separate RARS messages from program output using redirection.</td><td>4.3</td></tr>
-<tr><td width=40 align="right"><tt>nc</tt></td><td>copyright notice will not be displayed.  Useful if redirecting or piping program output.</td><td>3.5</td></tr>
 <tr><td width=40 align="right"><tt>np</tt></td><td>pseudo-instructions or extended instruction formats are not permitted.</td><td>3.0</td></tr>
 <tr><td width=40 align="right"><tt>p</tt></td><td>project option - will assemble the specified file and all other assembly files (*.asm; *.s) in its directory.</td><td>3.1</td></tr>
 <tr><td width=40 align="right"><tt>se<i>n</i></tt></td><td>terminate RARS with exit code <i>n</i> if simulate (run) error occurs</td><td>4.1</td></tr>
 <tr><td width=40 align="right"><tt>sm</tt></td><td>start execution at statement having global label 'main' if defined</td><td>3.8</td></tr>
 <tr><td width=40 align="right"><tt>smc</tt></td><td>Self Modifying Code - Program can write and execute in either text or data segment</td><td>4.4</td></tr>
+<tr><td width=40 align="right"><tt>version</tt></td><td>show copyright notice and version will not be displayed.</td><td></td></tr>
 <tr><td width=40 align="right"><tt>we</tt></td><td>assembler warnings will be considered errors.</td><td>3.5</td></tr>
 <tr><td width=40 align="right"><i>n</i></td><td>where <i>n</i> is an integer maximum count of execution steps to simulate.
                   If 0, negative or not specified, there is no maximum.</td><td>1.0</td></tr>

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -719,15 +719,13 @@ public class Launch {
         out.println("            32-bit address space, CompactDataAtZero for a 32KB memory with");
         out.println("            data segment at address 0, or CompactTextAtZero for a 32KB");
         out.println("            memory with text segment at address 0.");
-        out.println("     me  -- display RARS messages to standard err instead of standard out. ");
-        out.println("            Can separate messages from program output using redirection");
-        out.println("     nc  -- do not display copyright notice (for cleaner redirected/piped output).");
         out.println("     np  -- use of pseudo instructions and formats not permitted");
         out.println("      p  -- Project mode - assemble all files in the same directory as given file.");
         out.println("  se<n>  -- terminate RARS with integer exit code <n> if a simulation (run) error occurs.");
         out.println("     sm  -- start execution at statement with global label main, if defined");
         out.println("    smc  -- Self Modifying Code - Program can write and branch to either text or data segment");
         out.println("    rv64 -- Enables 64 bit assembly and executables (Not fully compatible with rv32)");
+        out.println(" version -- Show version and copyright");
         out.println("    <n>  -- where <n> is an integer maximum count of steps to simulate.");
         out.println("            If 0, negative or not specified, there is no maximum.");
         out.println(" x<reg>  -- where <reg> is number or name (e.g. 5, t3, f10) of register whose ");

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -151,7 +151,7 @@ public class Launch {
         memoryDisplayList = new ArrayList<>();
         filenameList = new ArrayList<>();
         MemoryConfigurations.setCurrentConfiguration(MemoryConfigurations.getDefaultConfiguration());
-        out = System.out;
+        out = System.err;
 
         if (!parseCommandArgs(args)) {
             System.exit(Globals.exitCode);
@@ -255,16 +255,11 @@ public class Launch {
 
     private boolean parseCommandArgs(String[] args) {
         String noCopyrightSwitch = "nc";
-        String displayMessagesToErrSwitch = "me";
         boolean argsOK = true;
         boolean inProgramArgumentList = false;
         programArgumentList = null;
         if (args.length == 0)
             return true; // should not get here...
-        // If the option to display RARS messages to standard erro is used,
-        // it must be processed before any others (since messages may be
-        // generated during option parsing).
-        processDisplayMessagesToErrSwitch(args, displayMessagesToErrSwitch);
         displayCopyright(args, noCopyrightSwitch);  // ..or not..
         if (args.length == 1 && args[0].equals("h")) {
             displayHelp();
@@ -286,8 +281,8 @@ public class Launch {
                 inProgramArgumentList = true;
                 continue;
             }
-            // messages-to-standard-error switch already processed, so ignore.
-            if (args[i].toLowerCase().equals(displayMessagesToErrSwitch)) {
+            // messages-to-standard-error removed, so ignore.
+            if (args[i].toLowerCase().equals("me")) {
                 continue;
             }
             // no-copyright switch already processed, so ignore.
@@ -671,18 +666,6 @@ public class Launch {
         }
     }
 
-    ///////////////////////////////////////////////////////////////////////
-    //  If option to display RARS messages to standard err (System.err) is
-    //  present, it must be processed before all others.  Since messages may
-    //  be output as early as during the command parse.
-    private void processDisplayMessagesToErrSwitch(String[] args, String displayMessagesToErrSwitch) {
-        for (String arg : args) {
-            if (arg.toLowerCase().equals(displayMessagesToErrSwitch)) {
-                out = System.err;
-                return;
-            }
-        }
-    }
     ///////////////////////////////////////////////////////////////////////
     //  Decide whether copyright should be displayed, and display
     //  if so.

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -5,7 +5,6 @@ import rars.riscv.InstructionSet;
 import rars.riscv.dump.DumpFormat;
 import rars.riscv.dump.DumpFormatLoader;
 import rars.riscv.hardware.*;
-import rars.simulator.ProgramArgumentList;
 import rars.simulator.Simulator;
 import rars.util.Binary;
 import rars.util.FilenameFinder;
@@ -20,8 +19,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Observable;
-import java.util.Observer;
 
 /*
 Copyright (c) 2003-2012,  Pete Sanderson and Kenneth Vollmar

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -146,8 +146,8 @@ public class Launch {
         assembleProject = false;
         countInstructions = false;
         instructionCount = 0;
-        assembleErrorExitCode = 0;
-        simulateErrorExitCode = 0;
+        assembleErrorExitCode = 1;
+        simulateErrorExitCode = 2;
         registerDisplayList = new ArrayList<>();
         memoryDisplayList = new ArrayList<>();
         filenameList = new ArrayList<>();

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -254,13 +254,11 @@ public class Launch {
     // Returns true if command args parse OK, false otherwise.
 
     private boolean parseCommandArgs(String[] args) {
-        String noCopyrightSwitch = "nc";
         boolean argsOK = true;
         boolean inProgramArgumentList = false;
         programArgumentList = null;
         if (args.length == 0)
             return true; // should not get here...
-        displayCopyright(args, noCopyrightSwitch);  // ..or not..
         if (args.length == 1 && args[0].equals("h")) {
             displayHelp();
             return false;
@@ -285,8 +283,12 @@ public class Launch {
             if (args[i].toLowerCase().equals("me")) {
                 continue;
             }
-            // no-copyright switch already processed, so ignore.
-            if (args[i].toLowerCase().equals(noCopyrightSwitch)) {
+            // no-copyright switch removed, so ignore.
+            if (args[i].toLowerCase().equals("nc")) {
+                continue;
+            }
+            if (args[i].toLowerCase().equals("version")) {
+                displayVersion();
                 continue;
             }
             if (args[i].toLowerCase().equals("dump")) {
@@ -666,17 +668,11 @@ public class Launch {
         }
     }
 
-    ///////////////////////////////////////////////////////////////////////
-    //  Decide whether copyright should be displayed, and display
-    //  if so.
-
-    private void displayCopyright(String[] args, String noCopyrightSwitch) {
-        for (String arg : args) {
-            if (arg.toLowerCase().equals(noCopyrightSwitch)) {
-                return;
-            }
-        }
-        out.println("RARS " + Globals.version + "  Copyright " + Globals.copyrightYears + " " + Globals.copyrightHolders + "\n");
+    /**
+     * Display version and copyright.
+     * */
+    private void displayVersion() {
+        out.println("RARS " + Globals.version + " Copyright " + Globals.copyrightYears + " " + Globals.copyrightHolders + "\n");
     }
 
 

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -131,6 +131,7 @@ public class Launch {
     private ArrayList<String> programArgumentList; // optional program args for program (becomes argc, argv)
     private int assembleErrorExitCode;  // RARS command exit code to return if assemble error occurs
     private int simulateErrorExitCode;// RARS command exit code to return if simulation error occurs
+    private int maxStepsErrorExitCode;// RARS command exit code to return if max number of instructions is reached
 
     public static void main(String[] args){
         new Launch(args);
@@ -148,6 +149,7 @@ public class Launch {
         instructionCount = 0;
         assembleErrorExitCode = 1;
         simulateErrorExitCode = 2;
+        maxStepsErrorExitCode = 3;
         registerDisplayList = new ArrayList<>();
         memoryDisplayList = new ArrayList<>();
         filenameList = new ArrayList<>();
@@ -512,6 +514,7 @@ public class Launch {
                     Simulator.Reason done = program.simulate();
                     if (done == Simulator.Reason.MAX_STEPS) {
                         out.println("\nProgram terminated when maximum step limit " + options.maxSteps + " reached.");
+                        Globals.exitCode = maxStepsErrorExitCode;
                         break;
                     } else if (done == Simulator.Reason.CLIFF_TERMINATION) {
                         out.println("\nProgram terminated by dropping off the bottom.");


### PR DESCRIPTION
A bunch of small improvements

* 1, 2 and 3 return code are now used by default when there is an assembly error, a runtime error or a max instruction reached (timeout).
* stderr is always used for messages
* versions and copyright are displayed only when 'version' is asked

Seriously, the CLI option syntax is weird, maybe we should rewrite it and use classic `--option` ?