### PR TITLE
Small nitpics on messages

### DIFF
--- a/src/rars/venus/run/RunGoAction.java
+++ b/src/rars/venus/run/RunGoAction.java
@@ -161,9 +161,9 @@ public class RunGoAction extends GuiAction {
         executePane.getDataSegmentWindow().updateValues();
         FileStatus.set(FileStatus.TERMINATED);
         SystemIO.resetFiles(); // close any files opened in MIPS program
-        // Bring CSRs to the front if terminated due to exception.
         if (pe != null) {
-            mainUI.getRegistersPane().setSelectedComponent(executePane.getControlAndStatusWindow());
+            // Do not bring CSRs to the front if terminated due to exception.
+            // It's annoying, and confusing for the beginners
             executePane.getTextSegmentWindow().setCodeHighlighting(true);
             executePane.getTextSegmentWindow().unhighlightAllSteps();
             executePane.getTextSegmentWindow().highlightStepAtAddress(RegisterFile.getProgramCounter() - 4);

--- a/src/rars/venus/run/RunGoAction.java
+++ b/src/rars/venus/run/RunGoAction.java
@@ -188,6 +188,7 @@ public class RunGoAction extends GuiAction {
                         pe.error().generateReport());
                 mainUI.getMessagesPane().postMessage(
                         "\n" + name + ": execution terminated with errors.\n\n");
+                mainUI.getMessagesPane().postRunMessage("\n"+pe.error().getMessage());
                 break;
             case STOP:
                 mainUI.getMessagesPane().postMessage(

--- a/src/rars/venus/run/RunResetAction.java
+++ b/src/rars/venus/run/RunResetAction.java
@@ -103,7 +103,7 @@ public class RunResetAction extends GuiAction {
         // Aug. 24, 2005 Ken Vollmar
         SystemIO.resetFiles();  // Ensure that I/O "file descriptors" are initialized for a new program run
 
-        mainUI.getMessagesPane().postRunMessage(
+        mainUI.getMessagesPane().postMessage(
                 "\n" + name + ": reset completed.\n\n");
     }
 }

--- a/src/rars/venus/run/RunStepAction.java
+++ b/src/rars/venus/run/RunStepAction.java
@@ -126,6 +126,7 @@ public class RunStepAction extends GuiAction {
                     pe.error().generateReport());
             mainUI.getMessagesPane().postMessage(
                     "\n" + name + ": execution terminated with errors.\n\n");
+            mainUI.getMessagesPane().postRunMessage("\n"+pe.error().getMessage());
             FileStatus.set(FileStatus.TERMINATED); // should be redundant.
             executePane.getTextSegmentWindow().setCodeHighlighting(true);
             executePane.getTextSegmentWindow().unhighlightAllSteps();

--- a/src/rars/venus/run/RunStepAction.java
+++ b/src/rars/venus/run/RunStepAction.java
@@ -126,7 +126,6 @@ public class RunStepAction extends GuiAction {
                     pe.error().generateReport());
             mainUI.getMessagesPane().postMessage(
                     "\n" + name + ": execution terminated with errors.\n\n");
-            mainUI.getRegistersPane().setSelectedComponent(executePane.getControlAndStatusWindow());
             FileStatus.set(FileStatus.TERMINATED); // should be redundant.
             executePane.getTextSegmentWindow().setCodeHighlighting(true);
             executePane.getTextSegmentWindow().unhighlightAllSteps();


### PR DESCRIPTION
Reset messages is displayed on the assembly message tab

On termination due to exceptions, the exception message is also displayed on the runio message tab

Also, on exception the registers view is not forced to CSR