### PR TITLE
Implemented "Handle ret on main"

### DIFF
--- a/src/rars/assembler/Assembler.java
+++ b/src/rars/assembler/Assembler.java
@@ -281,7 +281,19 @@ public class Assembler {
                     textSegmentLines.add(statement); //not an instruction
                 }
             } // end of assembler second pass.
+
         }
+        // if the setting START AT MAIN is checked, we simulate a fake text segment
+        // and allow the user to put "ret" in main to emulate a compiled code.
+        if (Globals.getSettings().getBooleanSetting(Settings.Bool.START_AT_MAIN)) {
+            int endOfTextOffset = textAddress.get();
+            Memory.addressEndOfTextSegment = endOfTextOffset;
+            ProgramStatement fakeInstr1 = new ProgramStatement(0xa00893, endOfTextOffset );
+            machineList.add(fakeInstr1);
+            ProgramStatement fakeInstr2 = new ProgramStatement(0x73, endOfTextOffset + 4);
+            machineList.add(fakeInstr2);
+        }
+
         if (Globals.debug)
             System.out.println("Code generation begins");
         ///////////// THIRD MAJOR STEP IS PRODUCE MACHINE CODE FROM ASSEMBLY //////////

--- a/src/rars/riscv/hardware/Memory.java
+++ b/src/rars/riscv/hardware/Memory.java
@@ -6,7 +6,6 @@ import rars.Settings;
 import rars.SimulationException;
 import rars.riscv.Instruction;
 import rars.riscv.InstructionSet;
-import rars.util.Binary;
 
 import java.util.Collection;
 import java.util.Observable;
@@ -190,6 +189,10 @@ public class Memory extends Observable {
     // always returns this instance.
 
     private static Memory uniqueMemoryInstance = new Memory();
+
+    // Pointer for when the main option is enabled, allowing the user to ret to an injected
+    // text segment that allows us to exit properly like a real executable would
+    public static int addressEndOfTextSegment;
 
 
     /*

--- a/src/rars/riscv/hardware/RegisterFile.java
+++ b/src/rars/riscv/hardware/RegisterFile.java
@@ -169,6 +169,8 @@ public class RegisterFile {
         int mainAddr = Globals.symbolTable.getAddress(SymbolTable.getStartLabel());
         if (startAtMain && mainAddr != SymbolTable.NOT_FOUND && Memory.inTextSegment(mainAddr)) {
             initializeProgramCounter(mainAddr);
+            // Make the main function return to a text segment that contains "li a7, 10; ecall"
+            updateRegister(1, Memory.addressEndOfTextSegment);
         } else {
             initializeProgramCounter((int)programCounter.getResetValue());
         }


### PR DESCRIPTION
We wanted to emulate a more realistic compiler (ie gcc with __start that calls main). To do so, we needed to create a fake text segment with pre-built instructions. 

When start at main is enabled in the settings, and main is recognized as global : 
- The instructions "li a7, 10 ; ecall" (which exits the program succesfully) are injected at the end of the text segment
- The return address register is initialized with an address that points towards the injected text segment
- Added a pointer in "Memory" so the injected text segment address can be known by other parts of the code

Fix #115 