### PR TITLE
Update JaCoCo version for compatibility with Java 25.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.12</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>


### PR DESCRIPTION
Version 0.8.12 of JaCoCo doesn't know how to instrument Java 25's system classes, producing an `IllegalClassFormatException` during testing. The error is minor, since the tests still run and pass, but it is unsightly. Updating JaCoCo to version 0.8.14 fixes the issue.