### PR TITLE
Support .zero and .skip, which are aliases to .space. .zero is emitte…

### DIFF
--- a/src/rars/assembler/Assembler.java
+++ b/src/rars/assembler/Assembler.java
@@ -724,8 +724,8 @@ public class Assembler {
             } else {
                 this.dataAddress.set(this.alignToBoundary(this.dataAddress.get(),(int)Math.pow(2,value)));
             }
-        } else if (direct == Directives.SPACE) {
-            // TODO: add a fill type option
+        } else if (direct == Directives.SPACE || direct == Directives.ZERO || direct == Directives.SKIP) {
+            // TODO: add a fill value option
             // .space 90, 1 should fill memory with 90 bytes with the values 1
             if (passesDataSegmentCheck(token)) {
                 if (tokens.size() != 2) {

--- a/src/rars/assembler/Directives.java
+++ b/src/rars/assembler/Directives.java
@@ -25,7 +25,9 @@ public final class Directives {
     public static final Directives BYTE = new Directives(".byte", "Store the listed value(s) as 8 bit bytes");
     public static final Directives ALIGN = new Directives(".align", "Align next data item on specified byte boundary (0=byte, 1=half, 2=word, 3=double)");
     public static final Directives HALF = new Directives(".half", "Store the listed value(s) as 16 bit halfwords on halfword boundary");
-    public static final Directives SPACE = new Directives(".space", "Reserve the next specified number of bytes in Data segment");
+    public static final Directives SPACE = new Directives(".space", "Reserve the next specified number of bytes in Data segment, initialized to 0");
+    public static final Directives ZERO = new Directives(".zero", "Reserve the next specified number of bytes in Data segment, initialized to 0");
+    public static final Directives SKIP = new Directives(".skip", "Reserve the next specified number of bytes in Data segment, initialized to 0");
     public static final Directives DOUBLE = new Directives(".double", "Store the listed value(s) as double precision floating point");
     public static final Directives FLOAT = new Directives(".float", "Store the listed value(s) as single precision floating point");
     public static final Directives EXTERN = new Directives(".extern", "Declare the listed label and byte length to be a global data field");

--- a/test/space-zero-skip.s
+++ b/test/space-zero-skip.s
@@ -1,0 +1,33 @@
+#exit:42
+        .data
+buf1:   .space 80
+buf2:   .zero 80
+buf3:   .skip 80
+        
+        .text
+.globl main
+main:
+	la      t0, buf1
+        la      t1, buf2
+        la      t2, buf3
+        li      a0, 80
+loop:   beqz    a0, success
+        lb      t4, 0(t0)
+        bnez    t4, failure
+        lb      t4, 0(t1)
+        bnez    t4, failure
+        lb      t4, 0(t2)
+        bnez    t4, failure
+        addi    t0, t0, 1
+        addi    t1, t1, 1
+        addi    t2, t2, 1
+        addi    a0, a0, -1
+        j       loop
+success:
+	li a0, 42
+	li a7, 93
+	ecall
+failure:	
+	li a0, 0
+	li a7, 93
+	ecall


### PR DESCRIPTION
Support .zero and .skip, which are aliases to .space. 
.zero is emitted by gcc. 
This also improves the compatibility with RIPES.
Test included.