### PR TITLE
Improve synthetic return pad for the start-at-main option

### DIFF
--- a/src/rars/assembler/Assembler.java
+++ b/src/rars/assembler/Assembler.java
@@ -286,14 +286,14 @@ public class Assembler {
             } // end of assembler second pass.
 
         }
-        // if the setting START AT MAIN is checked, we simulate a fake text segment
+        // if the setting START AT MAIN is checked, we inject a synthetic return pad
         // and allow the user to put "ret" in main to emulate a compiled code.
         if (Globals.getSettings().getBooleanSetting(Settings.Bool.START_AT_MAIN)) {
             int endOfTextOffset = textAddress.get();
             Memory.addressEndOfTextSegment = endOfTextOffset;
-            ProgramStatement fakeInstr1 = new ProgramStatement(0xa00893, endOfTextOffset );
+            ProgramStatement fakeInstr1 = new ProgramStatement(0x05d00893, endOfTextOffset ); // li a7, 93 ; exit2
             machineList.add(fakeInstr1);
-            ProgramStatement fakeInstr2 = new ProgramStatement(0x73, endOfTextOffset + 4);
+            ProgramStatement fakeInstr2 = new ProgramStatement(0x73, endOfTextOffset + 4); // ecall
             machineList.add(fakeInstr2);
         }
 

--- a/src/rars/assembler/Assembler.java
+++ b/src/rars/assembler/Assembler.java
@@ -289,7 +289,7 @@ public class Assembler {
         // if the setting START AT MAIN is checked, we inject a synthetic return pad
         // and allow the user to put "ret" in main to emulate a compiled code.
         if (Globals.getSettings().getBooleanSetting(Settings.Bool.START_AT_MAIN)) {
-            int endOfTextOffset = textAddress.get();
+            int endOfTextOffset = textAddress.get()+0x200; // move it away
             Memory.addressEndOfTextSegment = endOfTextOffset;
             ProgramStatement fakeInstr1 = new ProgramStatement(0x05d00893, endOfTextOffset ); // li a7, 93 ; exit2
             machineList.add(fakeInstr1);

--- a/test/RarsTest.java
+++ b/test/RarsTest.java
@@ -199,6 +199,7 @@ public class RarsTest {
         opt.selfModifyingCode = true;
         Program p = new Program(opt);
         Globals.getSettings().setBooleanSettingNonPersistent(Settings.Bool.SELF_MODIFYING_CODE_ENABLED, true);
+        Globals.getSettings().setBooleanSettingNonPersistent(Settings.Bool.START_AT_MAIN, true);
 
         ArrayList<Instruction> insts = Globals.instructionSet.getInstructionList();
         for(Instruction inst : insts){

--- a/test/start_at_main.s
+++ b/test/start_at_main.s
@@ -1,0 +1,10 @@
+#exit:42
+	.global main
+
+	li a7, 93
+	li a0, 1 # Return value
+	ecall
+main:
+	li a7, 93 # Exit2
+	li a0, 42 
+	ecall

--- a/test/start_at_main_no_glob.s
+++ b/test/start_at_main_no_glob.s
@@ -1,0 +1,10 @@
+#exit:42
+	#.global main without it, startatmain does not works
+
+	li a7, 93
+	li a0, 42 # Return value
+	ecall
+main:
+	li a7, 93 # Exit2
+	li a0, 1
+	ecall

--- a/test/start_at_main_ret.s
+++ b/test/start_at_main_ret.s
@@ -1,0 +1,9 @@
+#exit:42
+	.global main
+
+	li a7, 93
+	li a0, 1 # Return value
+	ecall
+main:
+	li a0, 42
+	ret # free exit stub


### PR DESCRIPTION
* Use Exit2 instead of Exit, so main can return a value
* Move the return pad away so it makes the code and memory visualization cleaner, and avoid a fall through behavior
* Add tests (and activate the start-at-main option in the tests)